### PR TITLE
Initial commit for the NoFixup! Greasemonkey/Tampermonkey script

### DIFF
--- a/NoFixup.user.js
+++ b/NoFixup.user.js
@@ -1,0 +1,48 @@
+// ==UserScript==
+// @name         NoFixup!
+// @namespace    http://www.budw.in/
+// @version      0.2.2
+// @description  Disable the merge pull request button when fixup! commits exist in the current PR and haven't been squashed yet and hide the "Update branch" button.
+// @author       Drew Budwin
+// @match        http*://github.com/*
+// @require      https://code.jquery.com/jquery-2.2.1.js
+// @require      https://greasyfork.org/scripts/6250-waitforkeyelements/code/waitForKeyElements.js?version=23756
+// @grant        GM_log
+// ==/UserScript==
+
+waitForKeyElements (".merge-message", disableMergeButton);
+waitForKeyElements (".branch-action-item", hideUpdateBranchButton);
+
+function hideUpdateBranchButton()
+{    
+    var updateBranchButton = $('button:contains("Update branch")').hide();
+    
+    if (updateBranchButton !== null)
+    {        
+        updateBranchButton.hide();
+    }
+    else
+    {
+        console.log("WARNING: Can't locate active update branch button on page!");
+    }
+}
+
+function disableMergeButton()
+{
+    var mergeButton = $('button:contains("Merge pull request")');
+
+    if (mergeButton !== null && doesPRContainFixupCommits())
+    {        
+        mergeButton.text("Are there fixup! commits?");
+        mergeButton.prop("disabled", true);
+    }
+    else
+    {
+        console.log("WARNING: Can't locate active merge button on page!");
+    }
+}
+
+function doesPRContainFixupCommits()
+{    
+    return $('.timeline-commits:contains("fixup!")').length >= 1;
+}


### PR DESCRIPTION
-Will disable the "Merge pull request" button and replace the text with "Are there fixup! commits?" if the PR hasn't rebased and squash its fixup! commits yet.
-Will remove the "Update branch" button from view since it's often not used and clicking it can cause problems
